### PR TITLE
Sync clang-format to v20.1.4 [skip ci] [bot]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         always_run: true
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.8
+    rev: v20.1.4
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]


### PR DESCRIPTION
## Summary
The cudf submodule was updated and its mirrors-clang-format version changed to v20.1.4.
This PR updates .pre-commit-config.yaml to match.

Auto-generated by the sync-clang-format-version workflow.